### PR TITLE
Specific text posts list

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,44 @@ Here is the default blog plugin options:
 
 ### summary
 
-- Type: `boolean`
+- Type: `boolean` or `object`
 - Default: `true`
 
-Whether to extract summary from source markdowns.
+Whether to extract summary from source markdowns. If this value is set to `true`,
+the `summaryLenth` will be used to slice the text. If, on the other hand, this
+value is set to an object, you'll be able to specify a more complex pattern for
+the extraction of the summary. Available options:
+
+```js
+{
+  /*
+  Get as many paragraphs as the value of this property is set to. A paragraph
+  is considered to be a chunk of text followed by a "\n\n", but you can use
+  "paragraphsSeparator" in order to specify your own separator.
+
+  Once the chunks of text are splitted (with "paragraphsSeparator"), the first N
+  (as specified by the "paragraphs" property) chunks are obtained and joined
+  using the "paragrahpsJoiner" text, which is "<br><br>" by default.
+  */
+  paragraphs: 0,
+  paragraphsSeparator: "\n\n",
+  paragrahpsJoiner: "<br><br>",
+
+  /*
+  If you want the summary to extend until a given text pattern is found, use
+  this option. If the "stopSymbol" symbol is not found, the "summaryLength" will
+  be used as a safe fallback.
+  */
+  stopSymbol: '',
+
+  /*
+  Use these two options to append and/or prepend any text you want to the
+  summary.
+  */
+  prepend: ''
+  append: '',
+}
+```
 
 
 ### summaryLength

--- a/components/PostCard.vue
+++ b/components/PostCard.vue
@@ -33,7 +33,7 @@
           class="ui-post-summary text-secondary my-2"
           v-if="post.summary"
         >
-          {{ post.summary }}
+          <div v-html="post.summary"></div>
           <router-link
             :to="post.path"
             class="read-more"

--- a/components/PostCard.vue
+++ b/components/PostCard.vue
@@ -25,7 +25,7 @@
             </h3>
           </div>
           <div class="ui-post-summary text-secondary my-2" v-if="post.summary">
-            <div v-html="post.summary"></div>
+            <span v-html="post.summary"></span>
             <router-link :to="post.path" class="read-more"
               >Read more</router-link
             >

--- a/example/.vuepress/config.js
+++ b/example/.vuepress/config.js
@@ -5,6 +5,33 @@ module.exports = {
   summaryLength: 500,
   themeConfig: {
     summary: true,
+
+    // Example of advanced summary usage
+    /*
+    summary: {
+      // Use the first two paragraphs
+      paragraphs: 2,
+
+      // Let's assume that a paragraph is anything that ends with "..." and a new line
+      paragraphsSeparator: "...\n",
+
+      // And let's assume that we want to join back the extracted paragraphs with an empty space.
+      paragraphsJoiner: "",
+
+      // If we didn't want to use the "paragraphs" functionalty, and istead we
+      // want to extract a summary up until the first occurrence of a text, we'd
+      // use the "stopSymbol" functionality. Let's assume that we want to get
+      // all the text up until the first ";" followed by a new line appears in
+      // our text.
+      stopSymbol: ";\n",
+
+      // How about we add an emoji at the beginning of our summary?
+      prepend: "🔈",
+
+      // ... what about at the end?
+      append: "📖",
+    },
+    */
     nav: [
       {
         text: "Home",


### PR DESCRIPTION
This MR makes it possible to have better summaries. Now it's possible to get the first N paragraphs or the first N characters until a "stop pattern" is matched.

It's also possible to prepend and append text to the summary.

![Post___Develatio_s_Blog](https://user-images.githubusercontent.com/89727/80891496-abade380-8cc4-11ea-8d42-35910500171a.png)

This is completely backwards compatible, meaning it won't break any current configurations.