### PR TITLE
Improve translation possibilities

### DIFF
--- a/src/layouts/Post.vue
+++ b/src/layouts/Post.vue
@@ -55,7 +55,7 @@
             class="clearfix"
           >
             <h5 class="m-0">
-              {{ $t('read_more') }}
+              {{ $t('continue_reading') }}
             </h5>
           </div>
           <FeaturedPosts
@@ -70,7 +70,7 @@
             class="clearfix"
           >
             <h5 class="m-0">
-              Tags
+              {{ $t('tags_header') }}
             </h5>
           </div>
           <div>

--- a/src/plugins/Translation/locale/en.js
+++ b/src/plugins/Translation/locale/en.js
@@ -1,5 +1,7 @@
 module.exports = {
   read_more: 'Read more',
+  continue_reading: 'Continue reading',
+  tags_header: 'Tags',
   read_this_post: 'Read this Post',
   search_placeholder: 'Search',
   // eslint-disable-next-line


### PR DESCRIPTION
@z3by By adding the two properties you can improve the translation possibilities. As it's for example difficult in french to use the same words to encourage reading more of the article and reading more articles. Also some people may want to translate the header for the Tags component.